### PR TITLE
Update `non-steam-playtimes` to v1.2.0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -39,7 +39,7 @@
 	url = https://github.com/luthor112/steam-collections-plus.git
 [submodule "plugins/non-steam-playtimes"]
 	path = plugins/non-steam-playtimes
-	url = https://github.com/apteryxxyz/steam-plugin-non-steam-playtimes
+	url = https://github.com/apteryxxyz/steam-non-steam-playtimes
 [submodule "plugins/fullscreen-notifications-fix"]
 	path = plugins/fullscreen-notifications-fix
 	url = https://github.com/apteryxxyz/steam-plugin-fullscreen-notifications-fix


### PR DESCRIPTION
<!--  
  📌 **Before You Submit: Please Read Carefully**

  This template is **only** for submitting a **plugin update** to the store.  
  If you're doing anything else (e.g., submitting a plugin), please start over and select the appropriate PR template.

  Make sure you have:
  - (Optional, Highly encouraged) Tested and left feedback on **two other plugin PRs**.
  - Replaced **REPLACE_WITH_PLUGIN_NAME** and **REPLACE_WITH_SUMMARY**.
  - Completed the **Task Checklist**, including all Yes/No questions.
-->

# non-steam-playtimes

Dynamically update library app playtime, no longer need to navigate away and back to see updated playtime.
(And other things I changed in the past that I no longer remember lol)

## Task Checklist

### Developer

- [x] I am the original author or an authorized maintainer of this plugin.
- [x] I have complied with all license requirements for the libraries used, including providing appropriate notices where necessary.
- [x] My plugin is fully open source and does not depend on any external paid services, except for widely trusted and well-known platforms. Additionally, neither I nor anyone associated with me profits from any such services.

### Plugin Functionality

- [x] I have tested the plugin on both the **Stable** and **Beta** SteamOS update channels.

### Backend Configuration

* **Yes**: I use a standard Millennium python backend in my plugin.
* **No**: I use **custom binaries** that or rely on other FOSS projects that aren't written directly using Millennium's python backend. 

### Community Contribution

<!--  
  Link to your feedback on two plugin PRs in a comment on this PR.  
  This step is optional but strongly encouraged — plugin PRs without testing contributions may be reviewed more slowly.  
-->

- [ ] I have tested and left feedback on **two** other plugin pull requests.
- [ ] I have added links to those feedback comments in this PR.

---

## Testing Instructions

<!--  
  DO NOT CHECK THESE YOURSELF.  
  A third-party tester will check the appropriate box below **after verifying** your plugin.
-->

- [ ] Verified by a third party on **Steam Client Stable**.
- [ ] Verified by a third party on **Steam Client Beta**.
