### PR TITLE
feat: add valve-internal-enabler plugin

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -52,3 +52,6 @@
 [submodule "plugins/extendium"]
 	path = plugins/extendium
 	url = https://github.com/BossSloth/Extendium
+[submodule "plugins/valve-internal-enabler"]
+	path = plugins/valve-internal-enabler
+	url = https://github.com/veygax/valve-internal-enabler


### PR DESCRIPTION
this plugin enables the "Valve Internal" menu within Steam

<img width="1920" height="1032" alt="image" src="https://github.com/user-attachments/assets/32727eaf-5cd9-45ac-bd65-1d51ae69dd6a" />
