### PR TITLE
Add Proton Universal Prefix

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -79,3 +79,6 @@
 [submodule "plugins/gratitude"]
 	path = plugins/gratitude
 	url = https://github.com/BlythT/Gratitude-Millennium-Plugin
+[submodule "plugins/steam-proton-universal"]
+	path = plugins/steam-proton-universal
+	url = https://github.com/BlafKing/steam-proton-universal


### PR DESCRIPTION
# steam-proton-universal

A plugin that let's you use a fully universal steam Proton prefix

Hi there!
I've made another plugin which I'd like to submit :)

Currently on Linux, Steam's "Proton" creates a separate windows drive prefix for each game.
This plugin allows the user to define a single path which every game will then use as it's Proton Prefix.

It does the following:
1. Detect when a game is being launched
2. Find the game's compatdata folder location
3. If the folder exists with pre-existing files it:
   - Copies all content to your universal prefix (without overwriting existing files)
   - Removes the original compatdata folder
4. Creates a single symlink where the entire AppID's compatdata folder points directly to your universal prefix

v1.1.0 is an update to switch to LUA instead of Python, and to use millennium's in-steam configurator.

## Task Checklist

### Developer

- [x] I am the original author or an authorized maintainer of this plugin.
- [x] I have complied with all license requirements for the libraries used, including providing appropriate notices where necessary.
- [x] My plugin is fully open source and does not depend on any external paid services, except for widely trusted and well-known platforms. Additionally, neither I nor anyone associated with me profits from any such services.

### Plugin Functionality

- [x] I have tested the plugin on both the Stable and Beta Steam update channels.
- [x] My plugin is unique, or provides additional or alternative functionality to plugins already on the store.

### Backend Configuration

- [x] **No**: I use a standard Millennium python backend in my plugin.
- [x] **No**: I use custom binaries that or rely on other FOSS projects that aren't written directly using Millennium's python backend.

### Community Contribution

- [ ] I have tested and left feedback on two other plugin pull requests.
- [ ] I have added links to those feedback comments in this PR.
