### PR TITLE
Add steam-streak plugin

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -79,3 +79,6 @@
 [submodule "plugins/gratitude"]
 	path = plugins/gratitude
 	url = https://github.com/BlythT/Gratitude-Millennium-Plugin
+[submodule "plugins/steam-streak"]
+	path = plugins/steam-streak
+	url = https://github.com/BambooFury/steam-streak


### PR DESCRIPTION
Track daily Steam profile visits and game play streaks with beautiful fire level progression.

**Features**
- Daily streak tracking with click-to-claim functionality
- 5 fire levels: Spark (1d) → Blaze (10d) → Ascension (30d) → Nova (100d) → Eternal Flame (300d)
- Game streak widget in library showing consecutive play days
- Progress tracking with countdown timer
- Left-click for quick claim, right-click for detailed modal

**Repository**
https://github.com/BambooFury/steam-streak
