### PR TITLE
Add R6 Stats Tracker

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -79,3 +79,6 @@
 [submodule "plugins/gratitude"]
 	path = plugins/gratitude
 	url = https://github.com/BlythT/Gratitude-Millennium-Plugin
+[submodule "plugins/r6-stats"]
+	path = plugins/r6-stats
+	url = https://github.com/Nazza1996/Millennium-R6-Tracker


### PR DESCRIPTION
# R6 Stats Tracker

https://github.com/Nazza1996/Millennium-R6-Tracker

<img width="965" height="527" alt="image" src="https://github.com/user-attachments/assets/bc8815a4-3011-4290-86a2-2fd4575b7fc6" />


The R6 Stats Tracker integrates with Tracker.gg to display stats on user profiles.

Since siege uses Ubisoft ids instead of steam names, this plugin uses a local profile linking system. On each new user profile page you can enter the ubisoft id to link with the steam profile. This will then be saved with stats periodically updated.


For testing purposes, if you don't have/know any ubisoft profiles off the top of your head then checkout this [leaderboard](https://r6.tracker.network/r6siege/leaderboards?platformFamily=pc&season=41&gamemode=pvp_ranked&board=RankPoints&page=1)
(Make sure stats match whats shown in steam)