### PR TITLE
Add Player Count

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -79,3 +79,6 @@
 [submodule "plugins/gratitude"]
 	path = plugins/gratitude
 	url = https://github.com/BlythT/Gratitude-Millennium-Plugin
+[submodule "plugins/playcount-steambrew"]
+	path = plugins/playcount-steambrew
+	url = https://github.com/BarterClub/playcount-steambrew.git


### PR DESCRIPTION
## New Plugin: Player Count

**Repository:** https://github.com/BarterClub/playcount-steambrew
**Backend:** Lua
**Version:** 1.0.1

### What it does

Player Count is a Millennium plugin that displays real-time player counts from the Steam API on game pages in your library. When you click on a game, a small badge appears on the header image showing how many players are currently online.

- **Live player count** fetched from Steam's GetNumberOfCurrentPlayers API
- **Color-coded status dot** — changes color based on player count (green, blue, silver, gold, red)
- **Click to open SteamCharts** — clicking the badge opens the full SteamCharts page for that game
- **Auto-refresh** — player count updates periodically while viewing a game page
- **Configurable** — toggle visibility, alignment, and position offsets via the settings panel

### Technical details

- Frontend uses `Millennium.AddWindowCreateHook` + `MutationObserver` for game page detection
- HTTP requests handled by Lua backend via `callable()`
- Settings use Steam's native `ToggleField` and `SliderField` components
- No raw HTML input elements — fully compliant with Millennium plugin guidelines

### Credits

Ported from [playcount-decky](https://github.com/itsOwen/playcount-decky) (Steam Deck / Decky Loader) by itsOwen.
Architecture based on [hltb-millennium-plugin](https://github.com/jcdoll/hltb-millennium-plugin).