### PR TITLE
Add ProtonDB Status

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -73,3 +73,6 @@
 [submodule "plugins/gratitude"]
 	path = plugins/gratitude
 	url = https://github.com/BlythT/Gratitude-Millennium-Plugin
+[submodule "plugins/protondb-status"]
+	path = plugins/protondb-status
+	url = https://github.com/nyakuoff/protondb-badge


### PR DESCRIPTION
ProtonDB Status shows ProtonDB compatibility ratings directly in Steam’s game details stats row.

<img width="967" height="388" alt="image" src="https://github.com/user-attachments/assets/a2aabccc-366e-4b0b-ac06-eca4be9111ec" />