### PR TITLE
Add Steam Completion Companion

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -73,3 +73,6 @@
 [submodule "plugins/gratitude"]
 	path = plugins/gratitude
 	url = https://github.com/BlythT/Gratitude-Millennium-Plugin
+[submodule "plugins/steam-completion-companion"]
+	path = plugins/steam-completion-companion
+	url = https://github.com/sondermusik/steam-completion-companion


### PR DESCRIPTION
Adds Steam Completion Companion.

Displays SteamHunters completion statistics directly inside Steam library and store pages.

- Lightweight frontend + webkit integration
- Backend caching for SteamHunters API

Repository:
https://github.com/sondermusik/steam-completion-companion