### PR TITLE
Add steam-win-notify plugin

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -73,3 +73,6 @@
 [submodule "plugins/gratitude"]
 	path = plugins/gratitude
 	url = https://github.com/BlythT/Gratitude-Millennium-Plugin
+[submodule "steam-win-notify"]
+	path = steam-win-notify
+	url = https://github.com/SnakyWarrior/steam-win-notify


### PR DESCRIPTION
## steam-win-notify

Intercepts Steam in-client notifications and forwards them as native Windows 11 toast notifications. Also monitors controller connect/disconnect/battery status via XInput polling.

### Features
- Native Windows toasts for Steam notifications (downloads, chat, invites, achievements, etc.)
- Controller connect/disconnect/battery level notifications via XInput polling
- Settings panel to toggle which notification types appear
- Works entirely in the background — zero UI footprint

### Technical
- Written entirely with AI assistance (opencode / Claude)
- Frontend: TypeScript/React (SP) hooking into Steam's NotificationStore
- Backend: Lua with persistent PowerShell daemon for WinRT toasts + XInput polling
- No C++ compiler needed

### Maintainer wanted
I don't know how to code — this was made entirely with AI. If someone wants to take over maintenance, improve it, or fix bugs, please reach out. I'm happy to transfer the repo.