### PR TITLE
Add Steam Rating

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -73,3 +73,6 @@
 [submodule "plugins/gratitude"]
 	path = plugins/gratitude
 	url = https://github.com/BlythT/Gratitude-Millennium-Plugin
+[submodule "plugins/steam-rating"]
+	path = plugins/steam-rating
+	url = https://github.com/zoombrzoom/steam-rating.git


### PR DESCRIPTION
Adiciona o Steam Rating, um plugin do Millennium que permite aos usuários avaliar jogos da Biblioteca Steam com classificações de meia estrela e marcar jogos concluídos com contagens de vezes que foram concluídos.

Repositório de origem: https://github.com/zoombrzoom/steam-rating
Commit do plugin: b9b71a0ab633404734a11b40ab07a5f8ee3afcee