### PR TITLE
Add Steam Store Filters

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -73,3 +73,6 @@
 [submodule "plugins/gratitude"]
 	path = plugins/gratitude
 	url = https://github.com/BlythT/Gratitude-Millennium-Plugin
+[submodule "plugins/steam-store-filters"]
+	path = plugins/steam-store-filters
+	url = https://github.com/ZozoDanimo/steam-store-filters


### PR DESCRIPTION
## Steam Store Filters

Bypass Steam's promotion algorithm and discover games on your own terms. Search the full catalog by tags, filter by language, platform and features, and rank results by Wilson score or SteamDB rating instead of paid visibility.

### How to access the plugin

The plugin adds a **"Steam Store Filters"** button in the top-right search bar of the Steam Store page. Click it to open the search interface.

![Access button](https://raw.githubusercontent.com/ZozoDanimo/steam-store-filters/main/SSF%20Button%20location.png)

### Task Checklist

#### Developer
- [x] I am the original author or an authorized maintainer of this plugin.
- [x] I have complied with all license requirements for the libraries used, including providing appropriate notices where necessary.
- [x] My plugin is fully open source and does not depend on any external paid services, except for widely trusted and well-known platforms. Additionally, neither I nor anyone associated with me profits from any such services.

#### Plugin Functionality
- [x] I have tested the plugin on both the Stable and Beta Steam update channels.

#### Backend Configuration
- Yes: I use a standard Millennium Lua backend in my plugin.

#### Community Contribution
- [ ] I have tested and left feedback on two other plugin pull requests.
- [ ] I have added links to those feedback comments in this PR.