### PR TITLE
Add KZT to RUB Converter

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -73,3 +73,6 @@
 [submodule "plugins/gratitude"]
 	path = plugins/gratitude
 	url = https://github.com/BlythT/Gratitude-Millennium-Plugin
+[submodule "plugins/kzt_rub_converter"]
+	path = plugins/kzt_rub_converter
+	url = https://github.com/Morkamo/KZTtoRubConverter.git


### PR DESCRIPTION
Adds KZT to RUB Converter, a Millennium plugin that shows approximate RUB conversion next to KZT prices in the Steam Store.

Features:
- Detects KZT prices on Steam Store pages.
- Shows approximate RUB equivalent.
- Supports multiple exchange-rate providers with fallback.
- Caches exchange rate data.
- Falls back to fixed KZT / 6 conversion if all providers are unavailable.

Note:
This plugin shows an approximate currency conversion. It does not show the actual Steam regional price for Russia.