### PR TITLE
Add Game News

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -73,3 +73,6 @@
 [submodule "plugins/gratitude"]
 	path = plugins/gratitude
 	url = https://github.com/BlythT/Gratitude-Millennium-Plugin
+[submodule "plugins/game-news"]
+	path = plugins/game-news
+	url = https://github.com/YannisFouzi/steam-game-news-millenium


### PR DESCRIPTION
Adds **Game News** — a Millennium plugin for the Steam Desktop client that adds a **NEWS** button to the header, opening a personal feed of news for the games you follow, full-page inside Steam (with follow management, native toasts and settings).

- Repo: https://github.com/YannisFouzi/steam-game-news-millenium
- Backend type: Lua
- Privacy policy: https://gamenews.up.railway.app/privacy

Added as a submodule under `plugins/game-news`.