### PR TITLE
Add Game Backlog plugin

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -73,3 +73,6 @@
 [submodule "plugins/gratitude"]
 	path = plugins/gratitude
 	url = https://github.com/BlythT/Gratitude-Millennium-Plugin
+[submodule "plugins/game-backlog"]
+	path = plugins/game-backlog
+	url = https://github.com/EullerAron/game-backlog


### PR DESCRIPTION
Game Backlog — a plugin to track your Steam library status. Mark games as Completed, Playing, Plan to Play or Dropped; covers get a colored ribbon and each status maps to a native Steam collection (so you can also bulk-mark with Steam's multi-select).
Repo: https://github.com/EullerAron/game-backlog

Tested on Windows with the latest Millennium. Built frontend is committed under .millennium/.