### PR TITLE
Add steam-streak plugin

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -73,3 +73,6 @@
 [submodule "plugins/gratitude"]
 	path = plugins/gratitude
 	url = https://github.com/BlythT/Gratitude-Millennium-Plugin
+[submodule "plugins/steam-streak"]
+	path = plugins/steam-streak
+	url = https://github.com/Geegamr/steam-streak


### PR DESCRIPTION
## Steam Streak v1.1.0 🔥
### Game Streak Widget Improvements & Compatibility Fixes

#### Game Streak Widget
- **Streak-based fire icons**: Game streak widget now shows the correct fire level icon matching your streak length (Spark → Blaze → Ascension → Nova → Eternal Flame)
- **Cleaner design**: Removed background box for a sleeker, more modern look that blends into the library UI

#### Compatibility
- **SpaceTheme support**: Fixed invisible text when SpaceTheme is enabled
- **SpaceTheme support**: Fixed gray box that appeared around the game streak widget icon
- **General fixes**: Proper image sizing (28px), correct vertical alignment, and text positioning

### What different about this one
- This version is gonna keep being actively maintained