### PR TITLE
Add Discovery Queue Auto

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -73,3 +73,6 @@
 [submodule "plugins/gratitude"]
 	path = plugins/gratitude
 	url = https://github.com/BlythT/Gratitude-Millennium-Plugin
+[submodule "plugins/discovery-queue"]
+	path = plugins/discovery-queue
+	url = https://github.com/Kava-4/discovery-queue.git


### PR DESCRIPTION
## Summary

Adds **Discovery Queue Auto** as a Millennium plugin.

Repository: https://github.com/Kava-4/discovery-queue

Features:
- Automatically completes the Steam discovery queue via official store endpoints
- Claims free event stickers when available
- Steam toast notifications when queue trading cards or stickers are ready to collect
- Optional auto-run on the Discovery Queue page and auto-skip while browsing queue items
- Lightweight plugin (~13 KB installed, no backend)

Notes:
- Requires users to be logged into the Steam store inside the client
- Automates store queue actions during Steam sales/events only
- No API keys, telemetry, or external services
- Uses `store.steampowered.com` and `ISaleItemRewardsService` endpoints only

## Test plan

- [ ] Enable plugin in Millennium and open Store → Discovery Queue
- [ ] Verify **Auto Discover Queue** button appears on `/explore`
- [ ] Verify queue completion and optional sticker claim during an active sale
- [ ] Verify reward notification toast when queue or sticker is available