### PR TITLE
Add Proton Prefix Browser

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -73,3 +73,6 @@
 [submodule "plugins/gratitude"]
 	path = plugins/gratitude
 	url = https://github.com/BlythT/Gratitude-Millennium-Plugin
+[submodule "plugins/proton-prefix-browser"]
+	path = plugins/proton-prefix-browser
+	url = https://github.com/EvilNick2/proton-prefix-browser.git


### PR DESCRIPTION
# Proton Prefix Browser

I'm always digging into a game's Proton prefix to grab a save or tweak a config, and Steam only gives you Browse local files for the install folder. So I added a Browse Proton Prefix option right under it that opens the prefix in your file manager, plus a small button next to the gear on a game's page. It only shows up for games that actually have a prefix.

## Task Checklist

### Developer

- [x] I am the original author or an authorized maintainer of this plugin.
- [x] I have complied with all license requirements for the libraries used, including providing appropriate notices where necessary.
- [x] My plugin is fully open source and does not depend on any external paid services, except for widely trusted and well-known platforms. Additionally, neither I nor anyone associated with me profits from any such services.

### Plugin Functionality

- [x] I have tested the plugin on both the **Stable** and **Beta** Steam update channels.
- [x] My plugin is **unique**, or provides **additional or alternative functionality** to plugins already on the store.

### Backend Configuration

* **No**: I use a standard Millennium python backend in my plugin.
* **No**: I use **custom binaries** that or rely on other FOSS projects that aren't written directly using Millennium's python backend.

Note: the backend is Lua (Millennium's Lua backend, `backendType: "lua"`). There's no Python, no custom binaries, and no external FOSS projects.

### Community Contribution

- [ ] I have tested and left feedback on **two** other plugin pull requests.
- [ ] I have added links to those feedback comments in this PR.

---

## Testing Instructions

- [ ] Verified by a third party on **Steam Client Stable**.
- [ ] Verified by a third party on **Steam Client Beta**.
