### PR TITLE
Add Game Data Linker

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -73,3 +73,6 @@
 [submodule "plugins/gratitude"]
 	path = plugins/gratitude
 	url = https://github.com/BlythT/Gratitude-Millennium-Plugin
+[submodule "plugins/game-data-linker"]
+	path = plugins/game-data-linker
+	url = https://github.com/retrotoolsdev-wq/game-data-linker


### PR DESCRIPTION
Adds game-data-linker as a submodule.

It lets you link a non-Steam shortcut to a Steam AppID so its library page shows that game's real data: artwork, news, achievements, friend activity and community content. You set the AppID (or paste a store link) in the shortcut's Properties.

Repo: https://github.com/retrotoolsdev-wq/game-data-linker