### PR TITLE
feat: add default pull request template with update fallback option

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,10 @@
 <!--  
+  📢 UPDATING AN EXISTING PLUGIN INSTEAD?
+  Please use the update template:
+  - Copy the template content from: .github/PULL_REQUEST_TEMPLATE/PLUGIN-UPDATE.md
+  - Or create the PR using this URL: https://github.com/SteamClientHomebrew/PluginDatabase/compare?expand=1&template=PLUGIN-UPDATE.md
+-->
+<!--  
   📌 **Before You Submit: Please Read Carefully**
 
   This template is **only** for submitting a **new plugin** to the store.  


### PR DESCRIPTION
New contributors haven't been finding the templates (so most PRs don't use them). This fixes that by adding a default github PR template (defaults to new plugin but has comment header with instructions pointing at the update template also)