### PR TITLE
Add CS2Tracker Extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -73,3 +73,6 @@
 [submodule "plugins/gratitude"]
 	path = plugins/gratitude
 	url = https://github.com/BlythT/Gratitude-Millennium-Plugin
+[submodule "plugins/cs2tracker-extension"]
+	path = plugins/cs2tracker-extension
+	url = https://github.com/MuhammedResulBilkil/cs2tracker-extension


### PR DESCRIPTION
# CS2Tracker Extension

Adds a CS2Tracker button to Steam community profile pages and a small badge to each row of the friends, pending-invite and recently-played-with lists. Clicking through opens `cs2tracker.gg/stats/{steamid64}` for that player.

Each badge and button reads its own player's Steam ID from the page it sits on, so a friend-row badge opens that friend's stats rather than the profile owner's. Three toggles in the settings panel control the profile button, the friend-list badges, and whether links open in Steam's browser or the system one.

Repository: https://github.com/MuhammedResulBilkil/cs2tracker-extension
Pinned at [`f5e67bf`](https://github.com/MuhammedResulBilkil/cs2tracker-extension/releases/tag/v1.0.1), which is the `v1.0.1` release.

`v1.0.1` exists only to answer the review comment below: `thumbnail` and `splash_image` now point at the release tag rather than `master`, so the images the store renders are the images reviewed here. The rewrite happens in `semantic-release`'s prepare step, so every future release re-pins itself and there is no manual step to forget. No functional change to the plugin.

| | |
|---|---|
| Profile button | ![profile button](https://raw.githubusercontent.com/MuhammedResulBilkil/cs2tracker-extension/master/assets/screenshots/profile-button.png) |
| Friend list badge | ![friend list](https://raw.githubusercontent.com/MuhammedResulBilkil/cs2tracker-extension/master/assets/screenshots/friend-list.png) |
| Settings | ![settings](https://raw.githubusercontent.com/MuhammedResulBilkil/cs2tracker-extension/master/assets/screenshots/settings-panel.png) |

### How it differs from the plugins already on the store

`leetify-extension` and `csstats-extension` link out to Leetify and CSStats respectively; this one links to CS2Tracker, a different site. The profile button is deliberately styled to match the CSStats button's height, ground colour and wordmark treatment so that the three sit together as a row rather than competing visually — the screenshot above shows all three installed side by side.

The friend-list badges are the part I haven't seen elsewhere: a per-row link on the friends, pending-invite and recently-played-with lists, each resolving that row's own account.

There is also #209 (Profile Button Config) open in this queue, which lets a user define arbitrary profile buttons from a URL template. I don't think the two make each other redundant, and I'd rather say why than leave a reviewer to wonder: PBC is a general tool for profile pages, configured by the user; this is a zero-configuration plugin for one site that also covers the friends lists, which a profile-page button cannot reach. Someone who wants a button for an arbitrary site is better served by PBC. If the maintainers see it differently I'd genuinely rather hear it now than after a merge.

## Task Checklist

### Developer

- [x] I am the original author or an authorized maintainer of this plugin.
- [x] I have complied with all license requirements for the libraries used, including providing appropriate notices where necessary.
- [x] My plugin is fully open source and does not depend on any external paid services, except for widely trusted and well-known platforms. Additionally, neither I nor anyone associated with me profits from any such services.

### Plugin Functionality

- [x] I have tested the plugin on both the **Stable** and **Beta** Steam update channels.
- [x] My plugin is **unique**, or provides **additional or alternative functionality** to plugins already on the store.

### Backend Configuration

* **Yes**: I use a standard Millennium **lua** backend in my plugin. — `"backendType": "lua"` in `plugin.json`. It requires `logger`, `millennium` and `json`, all of which Millennium preloads, and nothing else.
* **No**: I use **custom binaries** that or rely on other FOSS projects that aren't written directly using Millennium's **lua** backend. — no binaries, no bundled executables, no third-party runtime dependencies. The backend is a single 4.9 KB `main.lua`.

### Community Contribution

- [x] I have tested and left feedback on **two** other plugin pull requests.
- [x] I have added links to those feedback comments in this PR.

Both were read against their pinned commit, then installed and run on Steam Stable with Millennium:

- #207 — CSST.at Extension: https://github.com/SteamClientHomebrew/PluginDatabase/pull/207#issuecomment-5128129063
- #175 — CS Weekly Drop Reset: https://github.com/SteamClientHomebrew/PluginDatabase/pull/175#issuecomment-5128129221

---

## Testing Instructions

Install, restart Steam, enable under **Millennium → Plugins**, then:

1. Open any Steam community profile — a **CS2TRACKER.GG** button should appear in the right-hand column, below the persona block. Click it; the stats page should be for that player.
2. Open a `/id/{vanity}` profile as well. The Steam ID isn't in that URL, so this exercises a different resolution path.
3. Open your friends list — each row should carry a small CS2Tracker badge. **Click badges on three different rows** and confirm each opens that friend's stats rather than the page owner's.
4. Type in the friends search box and clear it a few times; newly rendered rows should still get badges.
5. In the settings panel, switch **Show on friend lists** off, then reopen the friends page — the badges should be gone. Settings are read once per page load by design, so an already-open page keeps its old state until reloaded.
6. Turn **Open in external browser** on, reopen a profile, and click the button — it should open your system browser rather than Steam's.
7. Disable the plugin and reopen a profile — no button, no badges, no leftover `<style>` element.

Network behaviour, if you want to check it: the plugin makes exactly one request of its own, to `steamcommunity.com` for the current page's `?xml=1` view, and only when the profile's Steam ID isn't already available from the URL or the page's own globals. Everything else is a link the user clicks.

- [ ] Verified by a third party on **Steam Client Stable**.
- [ ] Verified by a third party on **Steam Client Beta**.





