### PR TITLE
Add Steam Share

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -73,3 +73,6 @@
 [submodule "plugins/gratitude"]
 	path = plugins/gratitude
 	url = https://github.com/BlythT/Gratitude-Millennium-Plugin
+[submodule "plugins/steam-share"]
+	path = plugins/steam-share
+	url = https://github.com/wopln/Steam-Share


### PR DESCRIPTION
## Summary

This pull request adds **Steam Share** to the Millennium Plugin Database.

Repository:
https://github.com/wopln/Steam-Share

### Features

- Adds a native **Share** button to Steam Store game pages.
- Allows selecting one or multiple Steam friends.
- Sends the current game's Steam Store link directly through Steam Chat.
- Matches Steam's native interface and styling.

Thank you for your review!