### PR TITLE
Add Exclude collections in collection

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -73,3 +73,6 @@
 [submodule "plugins/gratitude"]
 	path = plugins/gratitude
 	url = https://github.com/BlythT/Gratitude-Millennium-Plugin
+[submodule "plugins/exclude-collections-in-collection"]
+	path = plugins/exclude-collections-in-collection
+	url = https://github.com/Norphirion/exclude-collections-in-collection


### PR DESCRIPTION
# Exclude collections in collection

Adds collection membership as a criterion for dynamic collections. Pick a dynamic collection, then either exclude every game that already belongs to other collections, or keep only those.

Steam's dynamic collections filter on tags, features, platforms and playtime, but not on other collections — so there is no way to express "everything I'm playing, minus everything I've already finished". This fills that gap. Rules are set per dynamic collection, stack on top of that collection's existing Steam criteria rather than replacing them, and refresh on their own when a source collection changes.

### Notes for review

The plugin never touches Steam's cloud-synced filter definition. It replaces the collection's in-memory filter object with a stand-in that inherits the same prototype, forwards every own property back to the original (MobX administration symbols included), and overrides only `Matches` and `bIsEmpty`. Disabling the plugin restores every collection exactly as it was, and nothing is written to the user's Steam Cloud data.

Only dynamic collections can be targeted: a static collection has no filter of its own, and routing one through the filtering path would discard hand-curated membership. Rules are stored in `localStorage`.

## Task Checklist

### Developer

- [x] I am the original author or an authorized maintainer of this plugin.
- [x] I have complied with all license requirements for the libraries used, including providing appropriate notices where necessary.
- [x] My plugin is fully open source and does not depend on any external paid services, except for widely trusted and well-known platforms. Additionally, neither I nor anyone associated with me profits from any such services.

### Plugin Functionality

- [x] I have tested the plugin on both the **Stable** and **Beta** Steam update channels.
- [x] My plugin is **unique**, or provides **additional or alternative functionality** to plugins already on the store.
  - The functionality of my plugin exists in the plugin "Collection+", but I wanted to have a standalone version of this options, with a user interface easier to use than adding some commands in the category settings

### Backend Configuration

* **No**: I use a standard Millennium python backend in my plugin.
* **No**: I use **custom binaries** that or rely on other FOSS projects that aren't written directly using Millennium's python backend.

### Community Contribution

- [x] I have tested and left feedback on **two** other plugin pull requests.
- [x] I have added links to those feedback comments in this PR.

Feedback left after source audits and live Steam Client Stable testing:
[Sortium - PR #231 ](https://github.com/SteamClientHomebrew/PluginDatabase/pull/231)
[Non-Steam Store Link - PR #223](https://github.com/SteamClientHomebrew/PluginDatabase/pull/223)
[Recent Chats - PR #221](https://github.com/SteamClientHomebrew/PluginDatabase/pull/221)
[Steam Wrapped - PR #220](https://github.com/SteamClientHomebrew/PluginDatabase/pull/220)

---

## Testing Instructions

- [x] Verified by a third party on **Steam Client Stable**.
- [ ] Verified by a third party on **Steam Client Beta**.