### PR TITLE
Add Steam Wrapped

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -91,3 +91,6 @@
 [submodule "plugins/Easy-Restart-Reload-for-Steam"]
 	path = plugins/Easy-Restart-Reload-for-Steam
 	url = https://github.com/SaiyajinK/Easy-Restart-Reload-for-Steam
+[submodule "plugins/steam-wrapped"]
+	path = plugins/steam-wrapped
+	url = https://github.com/wopln/Steam-Wrapped.git


### PR DESCRIPTION
## Summary

Adds Steam Wrapped to the Millennium Plugin Database as a submodule.

Plugin repository:
https://github.com/wopln/Steam-Wrapped

### Features

- A Steam Wrapped entry in the Store navigation bar.
- A dashboard with selectable periods such as this month, last month, the last three months, this year, and custom ranges.
- Locally tracked game sessions with live playtime for the currently running game.
- Period-based totals for playtime, games played, achievements, and favorite genre.
- Gaming insights including most played game, longest session, peak play time, and a 24-hour activity histogram.
- Recent achievements and recently played games, with links back to their native Steam Library pages.
- A high-resolution Share Summary PNG export of the dashboard.