### PR TITLE
Add Recent Chats

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -91,3 +91,6 @@
 [submodule "plugins/Easy-Restart-Reload-for-Steam"]
 	path = plugins/Easy-Restart-Reload-for-Steam
 	url = https://github.com/SaiyajinK/Easy-Restart-Reload-for-Steam
+[submodule "plugins/recent-chats"]
+	path = plugins/recent-chats
+	url = https://github.com/Alex979/Steam-Recent-Chats-plugin


### PR DESCRIPTION
# Summary

Adds "Recent Chats" to the Millennium Plugin Database as a submodule.

Plugin repository:
https://github.com/Alex979/Steam-Recent-Chats-plugin

### Features
- Adds a **Chats** tab to Steam's Friends window on both the desktop and in-game overlay.
- Sorts conversations by their latest activity.
- Shows the latest message, including game, lobby, Steam Playtest, trade, and broadcast invites.
- Displays timestamps and unread counts without changing Steam's unread state.
- Searches names and message previews.
- Opens Steam's normal chat window when a conversation is selected.

<img width="404" height="465" alt="recent-chat-plugin-screenshot" src="https://github.com/user-attachments/assets/dce6df2c-fecb-496b-9112-867b9d6c969d" />