### PR TITLE
Add Non-Steam Store Link

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -73,3 +73,6 @@
 [submodule "plugins/gratitude"]
 	path = plugins/gratitude
 	url = https://github.com/BlythT/Gratitude-Millennium-Plugin
+[submodule "plugins/millenium-non-steam-store-link-button"]
+	path = plugins/millenium-non-steam-store-link-button
+	url = https://github.com/eiztee/millenium-non-steam-store-link-button


### PR DESCRIPTION
<img width="1543" height="658" alt="image" src="https://github.com/user-attachments/assets/ac3dd67e-f448-49b1-82d5-3e72c93d82c5" />

A Millennium plugin that adds a "Find on Steam Store" chip next to Last Played/Playtime for games you've added to Steam manually (non-Steam shortcuts). Clicking it opens a Steam Store search for that game's name in your default browser.

Built on the same "game stat chip" anchor point and popup/route-watching pattern as the [Size on Disk] plugin by k0d13.