### PR TITLE
Add CS2 Profile Stats

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -73,3 +73,6 @@
 [submodule "plugins/gratitude"]
 	path = plugins/gratitude
 	url = https://github.com/BlythT/Gratitude-Millennium-Plugin
+[submodule "plugins/cs2-profile-stats"]
+	path = plugins/cs2-profile-stats
+	url = https://github.com/Shightrox/millennium-cs2-profile-stats.git


### PR DESCRIPTION
# CS2 Profile Stats

Embeds a compact CS2 performance card directly below the online-status block on Steam Community profiles. It combines Premier, Leetify, FACEIT, recent-match, Steam activity, and optional public-inventory data, then exposes the extended metrics in a Steam-native details view.

Repository: https://github.com/Shightrox/millennium-cs2-profile-stats

Stable release: [v0.4.5](https://github.com/Shightrox/millennium-cs2-profile-stats/releases/tag/v0.4.5)

Pinned commit: [`7e484dd`](https://github.com/Shightrox/millennium-cs2-profile-stats/commit/7e484ddb86ad4160d92106c2ad9a3e95faa97627)

Validation: [GitHub Actions](https://github.com/Shightrox/millennium-cs2-profile-stats/actions/runs/31855490438) passes dependency installation, manifest-version consistency, TypeScript checks, a production build, and Lua parsing.

No API key is required. A Leetify developer key is optional and only improves rate limits. The plugin has no telemetry and does not persist player statistics.

## Preview

### Premier + FACEIT

<img src="https://raw.githubusercontent.com/Shightrox/millennium-cs2-profile-stats/main/assets/screenshots/premier.png" alt="Full Steam profile with Premier and FACEIT data" width="100%">

### No Premier rating

<img src="https://raw.githubusercontent.com/Shightrox/millennium-cs2-profile-stats/main/assets/screenshots/nopremier.png" alt="Full Steam profile without a Premier rating" width="100%">

## How it differs from existing store plugins

- `millennium-faceit-stats` is focused on FACEIT. This plugin is an aggregate profile panel: Premier, Leetify performance, recent results, FACEIT, Steam playtime/account data, and an on-demand public-inventory estimate remain independently available when another provider has no data.
- `leetify-extension` and `csstats-extension` primarily provide links to external stat pages. This plugin keeps the useful summary and match context inside the Steam profile, with an expandable detail view.
- The card adapts to partial profiles, vanity URLs, private Steam data, missing Premier/FACEIT accounts, and optional-provider failures instead of hiding the whole panel.

## Task Checklist

### Developer

- [x] I am the original author or an authorized maintainer of this plugin.
- [x] I have complied with all license requirements for the libraries used, including providing appropriate notices where necessary.
- [x] My plugin is fully open source and does not depend on any external paid services, except for widely trusted and well-known platforms. Additionally, neither I nor anyone associated with me profits from any such services.

### Plugin Functionality

- [x] I have tested the plugin on both the **Stable** and **Beta** Steam update channels.
- [x] My plugin is **unique**, or provides **additional or alternative functionality** to plugins already on the store.

The plugin has been tested in the Steam Client **Stable** channel with Millennium. The combined checkbox remains open because the Beta channel has not yet been tested.

### Backend Configuration

* **No**: I use a standard Millennium Python backend in my plugin.
* **No**: I use custom binaries or rely on non-Millennium backend projects. The plugin uses a standard Millennium Lua backend (`backendType: lua`) and ships no executables or native libraries.

### Community Contribution

- [x] I have tested and left feedback on **two** other plugin pull requests.
- [x] I have added links to those feedback comments in this PR.

Feedback left after source audits and live Steam Client Stable testing:

- [Date added ? PR #218](https://github.com/SteamClientHomebrew/PluginDatabase/pull/218#issuecomment-5290013491)
- [Recent Chats ? PR #221](https://github.com/SteamClientHomebrew/PluginDatabase/pull/221#issuecomment-5290015356)

---

## Testing Instructions

1. Install the pinned commit, restart Steam, enable **CS2 Profile Stats** under **Millennium ? Plugins**, and save the changes.
2. Leave the optional Leetify API key empty to exercise the default keyless path.
3. Open any public Steam profile with a Premier rating and FACEIT data. A compact card should appear below the online-status block with Premier, Leetify rating, match count, K/D, Aim, reaction/AWP timing, win rate, recent form, and a two-line FACEIT footer containing the nickname, circular level indicator, lifetime matches, ELO, and K/D. Author-tested reproducible example: `https://steamcommunity.com/id/equagin/`.
4. Open any public Steam profile without a Premier rating. The card should still render correctly with the remaining available metrics. Author-tested reproducible example: `https://steamcommunity.com/id/phobiaofnipples/`.
5. Expand **Details** and verify the Overview, Matches, FACEIT, and Steam tabs. Missing/private values should show a neutral unavailable state rather than a plugin warning.
6. In the Steam tab, request the inventory estimate. Public inventories should be valued on demand; private inventories should report that they are unavailable.
7. Disable the plugin and reload a profile. The card and its injected styles should be removed.

Third-party data comes from the Leetify public API/web profile, Faceit Finder, optional SCOPE.GG public profile data, and Steam Community/Market endpoints. Provider requests are isolated so a single unavailable source does not suppress the other data.

- [ ] Verified by a third party on **Steam Client Stable**.
- [ ] Verified by a third party on **Steam Client Beta**.


