### PR TITLE
Add Steam Info for Non-Steam Games

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -85,3 +85,6 @@
 [submodule "plugins/steam-share"]
 	path = plugins/steam-share
 	url = https://github.com/wopln/Steam-Share
+[submodule "plugins/steam-info-for-nonsteam"]
+	path = plugins/steam-info-for-nonsteam
+	url = https://github.com/QofWands/steam-info-for-nonsteam.git


### PR DESCRIPTION
Adds `steam-info-for-nonsteam` (https://github.com/QofWands/steam-info-for-nonsteam) as a submodule under `plugins/`.

The plugin injects official Steam Store info (header image, genres, developer, release date, full description) directly into the native Steam Library detail page for non-Steam shortcuts, whenever the game is also officially sold on Steam. There's no separate settings panel. It patches Steam's own "About this game" section in place using Millennium's DOM APIs, so no JS or CSS bundle patching is involved.

MIT licensed.