### PR TITLE
Add Sort As Display

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -91,3 +91,6 @@
 [submodule "plugins/Easy-Restart-Reload-for-Steam"]
 	path = plugins/Easy-Restart-Reload-for-Steam
 	url = https://github.com/SaiyajinK/Easy-Restart-Reload-for-Steam
+[submodule "plugins/sort-as-display"]
+	path = plugins/sort-as-display
+	url = https://github.com/kuusei/steam-sort-as-display.git


### PR DESCRIPTION
# Sort As Display

Sort As Display copies Steam **sort name** onto the library sidebar `display_name` at runtime. Steam already uses sort name for ordering; this plugin also uses it as the visible list name.

Repository: https://github.com/kuusei/steam-sort-as-display

Pinned commit: `dd71d51 (0.2.1)`

## Task Checklist

### Developer

- [x] I am the original author or an authorized maintainer of this plugin.
- [x] I have complied with all license requirements for the libraries used, including providing appropriate notices where necessary.
- [x] My plugin is fully open source and does not depend on any external paid services, except for widely trusted and well-known platforms. Additionally, neither I nor anyone associated with me profits from any such services.

### Plugin Functionality

- [x] I have tested the plugin on both the **Stable** and **Beta** Steam update channels.
- [x] My plugin is **unique**, or provides **additional or alternative functionality** to plugins already on the store.

Unlike Game Renamer, this plugin does not keep a custom rename table. It uses the sort name already set in Steam properties as the library list display name.

### Backend Configuration

- **No**: I use a standard Millennium Python backend in my plugin.
- **No**: I use custom binaries or rely on external FOSS projects that are not part of Millennium's Starlight plugin environment.

The plugin uses Millennium's Lua backend and a TypeScript frontend. It does not bundle or execute custom native binaries.

### Community Contribution

- [x] I have tested and left feedback on **two** other plugin pull requests.
- [x] I have added links to those feedback comments in this PR.

https://github.com/SteamClientHomebrew/PluginDatabase/pull/243
https://github.com/SteamClientHomebrew/PluginDatabase/pull/235

## Testing Instructions

1. Install and enable **Sort As Display**, then restart Steam.
2. In the library sidebar, confirm titles match the **Sort As** field from Properties.
3. Change **Sort As** on a game and confirm the sidebar name updates without clicking another game first.
4. Restart Steam and confirm sort names still apply after library load.

- [ ] Verified by a third party on **Steam Client Stable**.
- [ ] Verified by a third party on **Steam Client Beta**.
