### PR TITLE
Add Steam Currency Converter

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -91,3 +91,6 @@
 [submodule "plugins/Easy-Restart-Reload-for-Steam"]
 	path = plugins/Easy-Restart-Reload-for-Steam
 	url = https://github.com/SaiyajinK/Easy-Restart-Reload-for-Steam
+[submodule "plugins/steam-currency-to-rub"]
+	path = plugins/steam-currency-to-rub
+	url = https://github.com/Jidos86/steam-currency-to-rub

--- a/.gitmodules
+++ b/.gitmodules
@@ -91,6 +91,6 @@
 [submodule "plugins/Easy-Restart-Reload-for-Steam"]
 	path = plugins/Easy-Restart-Reload-for-Steam
 	url = https://github.com/SaiyajinK/Easy-Restart-Reload-for-Steam
-[submodule "plugins/steam-currency-to-rub"]
-	path = plugins/steam-currency-to-rub
-	url = https://github.com/Jidos86/steam-currency-to-rub
+[submodule "plugins/steam-currency-converter"]
+	path = plugins/steam-currency-converter
+	url = https://github.com/Jidos86/steam-currency-converter


### PR DESCRIPTION
# Steam Currency Converter

Shows an approximate price **in the currency you pick** next to any Steam price — store, cart, checkout, community market, and the in-game overlay. It detects the account's wallet currency and appends `≈ N <cur>`, computed from public exchange-rate JSON ([fawazahmed0/exchange-api](https://github.com/fawazahmed0/exchange-api), 3 mirrors, cached 6 h). Not an official regional price — a raw exchange-rate estimate for quick comparison.

![Steam Currency Converter on the Steam store](https://raw.githubusercontent.com/Jidos86/steam-currency-converter/c42ae80/docs/demo.png)

Maintained fork of the existing (unlisted) https://github.com/KuroKim/steam-currency-to-rub. Differences:

- **Target currency is user-selectable** in the plugin settings (was hard-coded to RUB); all 40 Steam wallet currencies, as source *and* target.
- **Injection**: moved from a Lua `add_browser_js` `<script src>` (silently blocked by the store CSP in some regions, e.g. the Steam China store) to a `webkit/` module that Millennium loads with `Page.setBypassCSP`.
- Format-agnostic price parser (`1,234.56`, `1.234,56`, `1 199`, zero-decimal currencies).
- Full-precision rate (the original rounded to 2 decimals, breaking every sub-1 rate — USD/EUR/GBP/CNY, error up to tens of percent).
- Works on the new React cart/checkout.
- **DOM-only rendering** — `createElement` / `textContent`, no `innerHTML`, no `eval`, no remote code. Network is limited to the exchange-rate endpoints in `webkit/index.tsx`.

Settings persistence goes through the lua backend (`get_settings` / `set_target_currency` via `millennium.config`) because `usePluginConfig` / `pluginConfig` were unreliable in the current Millennium build.

No RUB/currency-conversion plugin is currently on the store.

## Task Checklist

### Developer

- [x] I am the original author or an authorized maintainer of this plugin.
- [x] I have complied with all license requirements for the libraries used, including providing appropriate notices where necessary. <!-- MIT; KuroKim and the upstream CJMAXiK userscript credited in LICENSE and README -->
- [x] My plugin is fully open source and does not depend on any external paid services, except for widely trusted and well-known platforms. Additionally, neither I nor anyone associated with me profits from any such services. <!-- only public exchange-rate JSON: jsDelivr / Cloudflare Pages / raw.githubusercontent -->

### Plugin Functionality

- [x] I have tested the plugin on both the **Stable** and **Beta** Steam update channels. <!-- incl. a CN-region account, which is what motivated the webkit-module rewrite -->
- [x] My plugin is **unique**, or provides **additional or alternative functionality** to plugins already on the store.

### Backend Configuration

* **No**: I use a standard Millennium python backend in my plugin.
* **No**: I use **custom binaries** that or rely on other FOSS projects that aren't written directly using Millennium's python backend. <!-- lua backend + webkit module only -->

### Community Contribution

- [x] I have tested and left feedback on **two** other plugin pull requests. <!-- reviews on #241 and #231 -->
- [x] I have added links to those feedback comments in this PR. <!-- see comments below -->

---

## Testing Instructions

<!-- DO NOT CHECK THESE YOURSELF. -->

- [ ] Verified by a third party on **Steam Client Stable**.
- [ ] Verified by a third party on **Steam Client Beta**.

<!--
How to test:
1. Install Millennium, add this plugin, enable it, fully restart Steam.
2. On a non-RUB account, open the store — each price gets an `≈` hint in the selected currency (default RUB).
3. Millennium -> Settings -> Plugins -> Steam Currency Converter -> pick a different target currency, restart Steam, verify prices update.
4. Check /cart, /checkout, a game page, search results, and the in-game overlay.
5. On an account already in the target currency the plugin does nothing.
-->