### PR TITLE
Add Steam Review Bar

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -91,3 +91,6 @@
 [submodule "plugins/Easy-Restart-Reload-for-Steam"]
 	path = plugins/Easy-Restart-Reload-for-Steam
 	url = https://github.com/SaiyajinK/Easy-Restart-Reload-for-Steam
+[submodule "plugins/steam-review-bar"]
+	path = plugins/steam-review-bar
+	url = https://github.com/SnowFallinSummer/Steam-Review-Bar.git


### PR DESCRIPTION
Adds Steam Review Bar, a webkit plugin that replaces Steam's vague review labels with a easy to understand blue/red percentage bar.

Repository:
https://github.com/SnowFallinSummer/Steam-Review-Bar