### PR TITLE
Add Steam Autoplay Mute

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -91,3 +91,6 @@
 [submodule "plugins/Easy-Restart-Reload-for-Steam"]
 	path = plugins/Easy-Restart-Reload-for-Steam
 	url = https://github.com/SaiyajinK/Easy-Restart-Reload-for-Steam
+[submodule "plugins/steam-autoplay-mute"]
+	path = plugins/steam-autoplay-mute
+	url = https://github.com/SnowFallinSummer/Steam-Autoplay-Mute.git


### PR DESCRIPTION
Adds Autoplay Mute, a webkit plugin that automatically mutes native HTML5 videos on Steam store/community pages to prevent unexpected autoplay audio.

Repository:
https://github.com/SnowFallinSummer/Steam-Autoplay-Mute