### PR TITLE
Add Lua Tools Activity

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -91,3 +91,6 @@
 [submodule "plugins/Easy-Restart-Reload-for-Steam"]
 	path = plugins/Easy-Restart-Reload-for-Steam
 	url = https://github.com/SaiyajinK/Easy-Restart-Reload-for-Steam
+[submodule "plugins/lua-tools-activity"]
+	path = plugins/lua-tools-activity
+	url = https://github.com/emanoeltosta2/millennium-lua-tools-activity.git


### PR DESCRIPTION
# Lua Tools Activity

Adds [Lua Tools Activity](https://github.com/emanoeltosta2/millennium-lua-tools-activity) to the Millennium plugin database.

The plugin detects games added by Lua Tools, preserves the original launch flow, and publishes their titles as Steam non-Steam game activity. It uses one hidden helper shortcut and includes its source plus a small Windows x64 helper binary.

## Task Checklist

### Developer

- [x] I am the original author or an authorized maintainer of this plugin.
- [ ] I have complied with all license requirements for the libraries used, including providing appropriate notices where necessary.
- [x] My plugin is fully open source and does not depend on external paid services.

### Plugin Functionality

- [ ] I have tested the plugin on both the **Stable** and **Beta** Steam update channels.
- [x] My plugin provides functionality specific to games added by Lua Tools.

### Backend Configuration

- **No**: I use a standard Millennium python backend in my plugin.
- **Yes**: I use a custom Windows x64 helper binary; its C# source is included in the repository.

### Community Contribution

- [ ] I have tested and left feedback on **two** other plugin pull requests.
- [ ] I have added links to those feedback comments in this PR.

---

## Testing Instructions

1. Install Lua Tools and add a game to Steam through it.
2. Install and enable **Lua Tools Activity** in Millennium, then restart Steam.
3. Start the Lua Tools game from the Steam library or its Steam-created desktop shortcut.
4. Check the Steam profile: it should display **In non-Steam game** followed by the game's title.
5. Close the game and confirm the activity clears.

Tested locally on the Steam Stable channel with several Lua Tools games and Steam-created desktop shortcuts. Steam Beta and independent verification are still pending.
