### PR TITLE
Add Non-Steam Activity

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -91,3 +91,6 @@
 [submodule "plugins/Easy-Restart-Reload-for-Steam"]
 	path = plugins/Easy-Restart-Reload-for-Steam
 	url = https://github.com/SaiyajinK/Easy-Restart-Reload-for-Steam
+[submodule "plugins/non-steam-activity"]
+	path = plugins/non-steam-activity
+	url = https://github.com/emanoeltosta2/millennium-lua-tools-activity.git


### PR DESCRIPTION
## Non-Steam Activity

A Windows Millennium plugin that publishes games added by Lua as non-Steam Steam activity. It preserves the original launch flow, supports launches from the library and Steam-created desktop shortcuts, reuses one hidden helper shortcut, and uses locally cached artwork.

## Task Checklist

### Developer

- [x] I am the original author or an authorized maintainer of this plugin.
- [x] I have complied with applicable license requirements and provided third-party notices.
- [x] The plugin is fully open source and does not depend on external paid services.

### Plugin Functionality

- [x] I tested the plugin on Steam Client Stable and Beta.
- [x] The plugin provides a focused non-Steam activity bridge for Lua-added games.

### Backend Configuration

- Standard Millennium Python backend: **No**
- Custom binary or non-Python FOSS component: **Yes** — `LuaStatusMonitor.exe` is included, and its complete C# source is in this repository. It requires the user-installed .NET 8 Runtime.

## Testing Instructions

1. Install Millennium, the plugin, Lua, and the .NET 8 Runtime on Windows.
2. Launch a Lua-added game from Steam, either through the library or a Steam-created desktop shortcut.
3. Confirm the profile shows the game as standard non-Steam activity, and that it clears shortly after the game exits.
4. Verify an official Steam game is unaffected.

The plugin is local-only: it does not bundle Lua or game files, use telemetry, or send personal data to third-party services.